### PR TITLE
WIP: improve database storage

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -43,7 +43,7 @@
   lineinfile: >
     dest=/etc/rundeck/rundeck-config.properties
     regexp="^dataSource.url"
-    line="dataSource.url=jdbc:mysql://{{ rundeck_database_host }}:{{ rundeck_database_port }}/{{ rundeck_database_name }}"
+    line="dataSource.url=jdbc:mysql://{{ rundeck_database_host }}:{{ rundeck_database_port }}/{{ rundeck_database_name }}?autoReconnect=true"
   notify:
     - restart rundeck
   tags:


### PR DESCRIPTION
We need to make some improvements to the rundeck configuration so that the database is used for storing project configuration and keys. http://rundeck.org/docs/administration/setting-up-an-rdb-datasource.html#configure-project-config-in-db
- [x] add autoreconnect
- [ ] configure DB storage for projects
- [ ] configure DB storage for keys
